### PR TITLE
Three extras Modules for examples/jsm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ test/treeshake/stats.html
 
 
 **/node_modules
+.esmcache

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "build": "rollup -c utils/build/rollup.config.js",
     "build-module": "ONLY_MODULE=true rollup -c utils/build/rollup.config.js",
     "build-examples": "rollup -c utils/build/rollup.examples.config.js && echo '\nFormatting...' && eslint examples/js --ext js --ignore-pattern libs --ignore-pattern ifc --fix",
-    "build-three-extra": "rollup -c utils/build/rollup.examples.config.js && echo '\nFormatting...' && eslint examples/js --ext js --ignore-pattern libs --ignore-pattern ifc --fix",
+    "build-three-extra": "rollup -c utils/build/rollup.extra.config.js",
     "dev": "concurrently --names \"ROLLUP,HTTP\" -c \"bgBlue.bold,bgGreen.bold\" \"rollup -c utils/build/rollup.config.js -w -m inline\" \"servez -p 8080\"",
     "lint": "eslint src --ext js",
     "lint-examples": "eslint examples/js examples/jsm --ext js --ignore-pattern libs --ignore-pattern ifc",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "build": "rollup -c utils/build/rollup.config.js",
     "build-module": "ONLY_MODULE=true rollup -c utils/build/rollup.config.js",
     "build-examples": "rollup -c utils/build/rollup.examples.config.js && echo '\nFormatting...' && eslint examples/js --ext js --ignore-pattern libs --ignore-pattern ifc --fix",
+    "build-three-extra": "rollup -c utils/build/rollup.examples.config.js && echo '\nFormatting...' && eslint examples/js --ext js --ignore-pattern libs --ignore-pattern ifc --fix",
     "dev": "concurrently --names \"ROLLUP,HTTP\" -c \"bgBlue.bold,bgGreen.bold\" \"rollup -c utils/build/rollup.config.js -w -m inline\" \"servez -p 8080\"",
     "lint": "eslint src --ext js",
     "lint-examples": "eslint examples/js examples/jsm --ext js --ignore-pattern libs --ignore-pattern ifc",

--- a/utils/build/rollup.examples.config.js
+++ b/utils/build/rollup.examples.config.js
@@ -163,7 +163,7 @@ function unmodularize() {
 
 }
 
-
+const rootFolder = path.resolve( __dirname, '../../' );
 const jsFolder = path.resolve( __dirname, '../../examples/js' );
 const jsmFolder = path.resolve( __dirname, '../../examples/jsm' );
 
@@ -188,6 +188,31 @@ const files = glob.sync( '**/*.js', { cwd: jsmFolder, ignore: [
 	'loaders/NodeMaterialLoader.js',
 	'offscreen/**/*',
 ] } );
+
+
+const makeFakeEntry = ( dependencies ) => {
+
+	const dir = path.resolve( rootFolder, '.esmcache' );
+	const file = path.resolve( dir, 'index.js' );
+	if ( ! fs.existsSync( dir ) ) {
+
+		fs.mkdirSync( dir );
+
+	}
+
+	let content = '';
+	for ( const dependency in dependencies ) {
+
+		content += `export * from ${dependency}\n`;
+
+	}
+
+	fs.writeFileSync( file, content );
+
+};
+
+makeFakeEntry( files );
+
 
 
 // Create a rollup config for each .js file

--- a/utils/build/rollup.examples.config.js
+++ b/utils/build/rollup.examples.config.js
@@ -167,10 +167,11 @@ const jsFolder = path.resolve( __dirname, '../../examples/js' );
 const jsmFolder = path.resolve( __dirname, '../../examples/jsm' );
 
 // list of all .js file nested in the examples/jsm folder
-const files = glob.sync( '**/*.js', { cwd: jsmFolder, ignore: [
+export const files = glob.sync( '**/*.js', { cwd: jsmFolder, ignore: [
 	// don't convert libs
 	'libs/**/*',
 	'loaders/ifc/**/*',
+	'three-extras.js',
 
 	// no non-module library
 	// https://unpkg.com/browse/@webxr-input-profiles/motion-controllers@1.0.0/dist/

--- a/utils/build/rollup.examples.config.js
+++ b/utils/build/rollup.examples.config.js
@@ -163,7 +163,6 @@ function unmodularize() {
 
 }
 
-const rootFolder = path.resolve( __dirname, '../../' );
 const jsFolder = path.resolve( __dirname, '../../examples/js' );
 const jsmFolder = path.resolve( __dirname, '../../examples/jsm' );
 
@@ -188,30 +187,6 @@ const files = glob.sync( '**/*.js', { cwd: jsmFolder, ignore: [
 	'loaders/NodeMaterialLoader.js',
 	'offscreen/**/*',
 ] } );
-
-
-const makeFakeEntry = ( dependencies ) => {
-
-	const dir = path.resolve( rootFolder, '.esmcache' );
-	const file = path.resolve( dir, 'index.js' );
-	if ( ! fs.existsSync( dir ) ) {
-
-		fs.mkdirSync( dir );
-
-	}
-
-	let content = '';
-	for ( const dependency in dependencies ) {
-
-		content += `export * from ${dependency}\n`;
-
-	}
-
-	fs.writeFileSync( file, content );
-
-};
-
-makeFakeEntry( files );
 
 
 

--- a/utils/build/rollup.extra.config.js
+++ b/utils/build/rollup.extra.config.js
@@ -1,0 +1,77 @@
+import path from 'path';
+import glob from 'glob';
+import fs from 'fs';
+
+const rootFolder = path.resolve( __dirname, '../../' );
+const jsmFolder = path.resolve( __dirname, '../../examples/jsm' );
+const outputPath = path.resolve( jsmFolder, 'three-extras.js' );
+
+const makeFakeEntry = ( dependencies ) => {
+
+	const dir = path.resolve( rootFolder, '.esmcache' );
+	const file = path.resolve( dir, 'index.js' );
+	if ( ! fs.existsSync( dir ) ) {
+
+		fs.mkdirSync( dir );
+
+	}
+
+	let content = '';
+	for ( const dependency of dependencies ) {
+
+		content += `export * from "${path.join( jsmFolder, dependency )}"\n`;
+
+	}
+
+	fs.writeFileSync( file, content );
+	return file;
+
+};
+
+const files = glob.sync( '**/*.js', { cwd: jsmFolder, ignore: [
+	// don't convert libs
+	'libs/**/*',
+	'loaders/ifc/**/*',
+	'three-extras.js',
+	// no non-module library
+	// https://unpkg.com/browse/@webxr-input-profiles/motion-controllers@1.0.0/dist/
+	'webxr/**/*',
+
+	// no non-module library
+	// https://unpkg.com/browse/web-ifc@0.0.17/
+	'loaders/IFCLoader.js',
+
+	'renderers/webgl/**/*',
+	'renderers/webgpu/**/*',
+	'renderers/nodes/**/*',
+	'nodes/**/*',
+	'loaders/NodeMaterialLoader.js',
+	'offscreen/**/*',
+] } );
+
+console.log( files );
+
+const file = makeFakeEntry( files );
+
+
+export default {
+
+	input: file,
+	treeshake: true,
+	minify: true,
+	external: ( a )=>{
+
+		if ( a.includes( 'three.module.js' ) ) {
+
+			return true;
+
+		}
+
+	},
+	// external: () => true, // don't bundle anything
+	plugins: [],
+	output: {
+		format: 'esm',
+		file: outputPath,
+	}
+};

--- a/utils/build/rollup.extra.config.js
+++ b/utils/build/rollup.extra.config.js
@@ -49,8 +49,6 @@ const files = glob.sync( '**/*.js', { cwd: jsmFolder, ignore: [
 	'offscreen/**/*',
 ] } );
 
-console.log( files );
-
 const file = makeFakeEntry( files );
 
 

--- a/utils/build/rollup.extra.config.js
+++ b/utils/build/rollup.extra.config.js
@@ -1,6 +1,7 @@
 import path from 'path';
 import glob from 'glob';
 import fs from 'fs';
+import { files } from './rollup.examples.config';
 
 const rootFolder = path.resolve( __dirname, '../../' );
 const jsmFolder = path.resolve( __dirname, '../../examples/jsm' );
@@ -28,35 +29,14 @@ const makeFakeEntry = ( dependencies ) => {
 
 };
 
-const files = glob.sync( '**/*.js', { cwd: jsmFolder, ignore: [
-	// don't convert libs
-	'libs/**/*',
-	'loaders/ifc/**/*',
-	'three-extras.js',
-	// no non-module library
-	// https://unpkg.com/browse/@webxr-input-profiles/motion-controllers@1.0.0/dist/
-	'webxr/**/*',
-
-	// no non-module library
-	// https://unpkg.com/browse/web-ifc@0.0.17/
-	'loaders/IFCLoader.js',
-
-	'renderers/webgl/**/*',
-	'renderers/webgpu/**/*',
-	'renderers/nodes/**/*',
-	'nodes/**/*',
-	'loaders/NodeMaterialLoader.js',
-	'offscreen/**/*',
-] } );
-
 const file = makeFakeEntry( files );
 
 
 export default {
 
 	input: file,
-	treeshake: true,
-	minify: true,
+	treeshake: false,
+	minify: false, // moved to compile time instead so output can be controlled
 	external: ( a )=>{
 
 		if ( a.includes( 'three.module.js' ) ) {


### PR DESCRIPTION
Added a rollup build for the three-extras module (optional) to compile all of the `examples/jsm` in `three/exaples/jsm/three-extra`

Command to generate the build is `npm run build-three-extra`